### PR TITLE
Fix FastLED controller template parameter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -237,7 +237,7 @@ void normalizeConfig(AppConfig& config)
   config.colorOrder = clampIndex(config.colorOrder, static_cast<uint8_t>(LedColorOrder::COLOR_ORDER_COUNT), DEFAULT_COLOR_ORDER);
 }
 
-template <typename CHIPSET>
+template <template<uint8_t DATA_PIN, fl::EOrder RGB_ORDER> class CHIPSET>
 void addFastLedControllerForOrder(LedColorOrder order)
 {
   switch (order) {


### PR DESCRIPTION
## Summary
- allow addFastLedControllerForOrder to accept FastLED chipset templates by constraining the template signature

## Testing
- not run (platformio command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1d19da35c8326b5cb54e5c6e3c1f9