### PR TITLE
Add configurable Art-Net interface preference

### DIFF
--- a/include/ArtNetNode.h
+++ b/include/ArtNetNode.h
@@ -6,6 +6,12 @@
 
 class ArtNetNode {
 public:
+  enum class InterfacePreference : uint8_t {
+    Ethernet = 0,
+    WiFi     = 1,
+    Auto     = 2,
+  };
+
   using ArtDmxCallback = void (*)(uint16_t universe, uint16_t length, uint8_t sequence,
                                   uint8_t* data, IPAddress remoteIP);
 
@@ -16,6 +22,8 @@ public:
   void setUniverseInfo(uint16_t startUniverse, uint16_t universeCount);
   void setNodeNames(const String& shortName, const String& longName);
   void updateNetworkInfo();
+  void setInterfacePreference(InterfacePreference preference);
+  IPAddress localIp() const { return m_localIp; }
 
 private:
   static constexpr uint16_t ARTNET_PORT = 6454;
@@ -35,5 +43,6 @@ private:
   String m_longName = F("PixelEtherLED Controller");
   std::array<uint8_t, ARTNET_MAX_BUFFER> m_buffer{};
   std::array<uint8_t, 6> m_mac{};
+  InterfacePreference m_interfacePreference = InterfacePreference::Ethernet;
 };
 


### PR DESCRIPTION
## Summary
- add a persisted configuration option to choose the preferred Art-Net interface (Ethernet or Wi-Fi)
- update the ArtNetNode to honour the selected interface and fall back automatically when needed
- expose the selection and current interface/IP in the web configuration UI

## Testing
- `platformio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a238f7fc83269f5e9f9bf01e4b95