### PR TITLE
Implement LED metadata lookup helpers

### DIFF
--- a/src/AppConfig.cpp
+++ b/src/AppConfig.cpp
@@ -1,0 +1,17 @@
+#include "AppConfig.h"
+
+const char* getChipName(uint8_t value)
+{
+  if (value < static_cast<uint8_t>(LedChipType::CHIP_TYPE_COUNT)) {
+    return CHIP_TYPE_NAMES[value];
+  }
+  return "Desconocido";
+}
+
+const char* getColorOrderName(uint8_t value)
+{
+  if (value < static_cast<uint8_t>(LedColorOrder::COLOR_ORDER_COUNT)) {
+    return COLOR_ORDER_NAMES[value];
+  }
+  return "Desconocido";
+}


### PR DESCRIPTION
## Summary
- add AppConfig.cpp implementing the LED chip and color order lookup helpers with bounds checking

## Testing
- not run (PlatformIO CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2ae96e3dc832692b2238690f6209f