### PR TITLE
Fix artnet input clamping for pre-C++17 build

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -651,7 +651,7 @@ void handleConfigPost()
   }
   if (g_server.hasArg("artnetInput")) {
     long parsed = g_server.arg("artnetInput").toInt();
-    parsed = std::clamp(parsed, 0L, 2L);
+    parsed = std::max(0L, std::min(2L, parsed));
     newConfig.artnetInput = static_cast<uint8_t>(parsed);
   }
   if (g_server.hasArg("wifiEnabled")) {


### PR DESCRIPTION
## Summary
- replace usage of std::clamp in handleConfigPost with nested std::min/std::max to avoid requiring C++17

## Testing
- platformio run *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c2830ac88326b21bae06b7ff5fe6