### PR TITLE
Ensure UDP binds to preferred interface

### DIFF
--- a/include/ArtNetNode.h
+++ b/include/ArtNetNode.h
@@ -36,6 +36,7 @@ private:
   WiFiUDP m_udp;
   ArtDmxCallback m_dmxCallback = nullptr;
   IPAddress m_localIp;
+  IPAddress m_boundIp;
   uint16_t m_listenPort = ARTNET_PORT;
   uint16_t m_startUniverse = 0;
   uint8_t m_portCount = 1;
@@ -44,5 +45,6 @@ private:
   std::array<uint8_t, ARTNET_MAX_BUFFER> m_buffer{};
   std::array<uint8_t, 6> m_mac{};
   InterfacePreference m_interfacePreference = InterfacePreference::Ethernet;
+  bool m_udpBound = false;
 };
 

--- a/src/ArtNetNode.cpp
+++ b/src/ArtNetNode.cpp
@@ -59,8 +59,9 @@ void ArtNetNode::begin(uint16_t port)
 {
   m_listenPort = port;
   m_udp.stop();
-  m_udp.begin(m_listenPort);
-  updateNetworkInfo();
+  m_udpBound = false;
+  m_boundIp = IPAddress((uint32_t)0);
+  refreshLocalInfo();
 }
 
 void ArtNetNode::setArtDmxCallback(ArtDmxCallback callback)
@@ -162,6 +163,17 @@ void ArtNetNode::refreshLocalInfo()
   }
 
   m_localIp = current;
+
+  if (!m_udpBound || m_boundIp != current) {
+    m_udp.stop();
+    if (current != IPAddress((uint32_t)0)) {
+      m_udp.begin(current, m_listenPort);
+    } else {
+      m_udp.begin(m_listenPort);
+    }
+    m_boundIp = current;
+    m_udpBound = true;
+  }
 
   esp_mac_type_t macType = ESP_MAC_ETH;
   if (active == ActiveInterface::WiFi) {


### PR DESCRIPTION
## Summary
- track the IP/interface currently bound to the Art-Net UDP socket
- rebind the socket to the preferred interface whenever the local address changes

## Testing
- not run (hardware-dependent)

------
https://chatgpt.com/codex/tasks/task_e_68e2c9f55b848326b67ea2337434ab17