### PR TITLE
Add Art-Net visualizer web page

### DIFF
--- a/src/WebUi.h
+++ b/src/WebUi.h
@@ -26,3 +26,6 @@ struct WebUiRuntime {
 String renderConfigPage(const AppConfig& config,
                         const WebUiRuntime& runtime,
                         const String& message);
+
+String renderVisualizerPage(const AppConfig& config,
+                            const WebUiRuntime& runtime);


### PR DESCRIPTION
## Summary
- add a live visualizer page with grid controls to preview the incoming Art-Net data from the LED buffer
- expose a JSON endpoint that streams LED color data to the web preview and register the new routes on the web server

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2caeed2048326983fe8d2098a470f