### PR TITLE
Fix factory reset input default state

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -481,7 +481,7 @@ bool checkFactoryResetOnBoot()
   if (FACTORY_RESET_ACTIVE_LOW) {
     pinMode(FACTORY_RESET_PIN, INPUT_PULLUP);
   } else {
-    pinMode(FACTORY_RESET_PIN, INPUT);
+    pinMode(FACTORY_RESET_PIN, INPUT_PULLDOWN);
   }
 
   if (!isFactoryResetPressed()) {


### PR DESCRIPTION
## Summary
- set the factory reset pin to use the appropriate pull resistor based on its active level

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2cfef85708326b8280dbd9659eece