### PR TITLE
Disable factory reset functionality

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1061,9 +1061,10 @@ void setup()
   Serial.begin(115200);
   delay(200);
 
-  if (checkFactoryResetOnBoot()) {
-    restoreFactoryDefaults();
-  }
+  // Temporarily disable factory reset on boot until feature is re-enabled.
+  // if (checkFactoryResetOnBoot()) {
+  //   restoreFactoryDefaults();
+  // }
 
   loadConfig();
 


### PR DESCRIPTION
## Summary
- comment out the factory reset call during setup to temporarily disable the feature

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2d468a1e0832688ab7f10413168c1