### PR TITLE
Prevent watchdog resets by yielding in main loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1112,4 +1112,9 @@ void loop()
 {
   artnet.read();
   g_server.handleClient();
+  // El lazo principal puede quedarse sin pausas cuando no hay tráfico de red
+  // que atender.  En algunos módulos ESP32 esto termina activando el watchdog
+  // de la tarea principal y provoca reinicios continuos.  Un pequeño retraso
+  // cede tiempo a las demás tareas del RTOS y mantiene alimentado el WDT.
+  delay(1);
 }


### PR DESCRIPTION
## Summary
- add a short delay to the main loop so the watchdog does not trip when there is no network traffic

## Testing
- not run (hardware-dependent firmware)

------
https://chatgpt.com/codex/tasks/task_e_68e2d618fb0c83268d4353842d9189b4