### PR TITLE
Fix WiFi cleanup assertion by initialising driver first

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -855,10 +855,15 @@ void handleFirmwareUpdatePost()
 
 void bringUpWiFi(const AppConfig& config)
 {
+  // Ensure the Wi-Fi driver and the TCP/IP stack are initialised before
+  // invoking any Wi-Fi API.  Calling functions such as scanDelete() or
+  // softAPdisconnect() while the driver is still stopped can trigger an
+  // assertion inside LwIP ("Invalid mbox").
+  WiFi.mode(WIFI_OFF);
+
   WiFi.scanDelete();
   WiFi.softAPdisconnect(true);
   WiFi.disconnect(true, true);
-  WiFi.mode(WIFI_OFF);
   delay(50);
 
   wifi_sta_running = false;


### PR DESCRIPTION
## Summary
- call `WiFi.mode(WIFI_OFF)` before invoking Wi-Fi cleanup helpers so the driver is ready and avoids the LwIP assertion

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2d768b1bc8326bf3e4e507a17419c