### PR TITLE
Restrict Art-Net packets to preferred network interface

### DIFF
--- a/include/ArtNetNode.h
+++ b/include/ArtNetNode.h
@@ -33,6 +33,13 @@ private:
   void refreshLocalInfo();
   void copyStringToField(const String& source, char* destination, size_t maxLength);
 
+  enum class ActiveInterface : uint8_t {
+    None = 0,
+    Ethernet,
+    WiFiStation,
+    WiFiAccessPoint,
+  };
+
   WiFiUDP m_udp;
   ArtDmxCallback m_dmxCallback = nullptr;
   IPAddress m_localIp;
@@ -44,5 +51,6 @@ private:
   std::array<uint8_t, ARTNET_MAX_BUFFER> m_buffer{};
   std::array<uint8_t, 6> m_mac{};
   InterfacePreference m_interfacePreference = InterfacePreference::Ethernet;
+  ActiveInterface m_activeInterface = ActiveInterface::None;
 };
 


### PR DESCRIPTION
## Summary
- track the active network interface when refreshing Art-Net node state
- update MAC selection to match the chosen interface type
- ignore UDP packets that arrive on a non-preferred interface to prevent alternating sources

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2eaabe80c83269e17556105f27038