### PR TITLE
Use stored local IP when handling Art-Net packets

### DIFF
--- a/src/ArtNetNode.cpp
+++ b/src/ArtNetNode.cpp
@@ -255,7 +255,7 @@ void ArtNetNode::read()
     return;
   }
 
-  IPAddress packetLocal = m_udp.localIP();
+  IPAddress packetLocal = m_localIp;
   bool dropPacket = false;
 
   if (packetLocal != IPAddress((uint32_t)0)) {


### PR DESCRIPTION
## Summary
- replace usage of WiFiUDP::localIP() with the cached local interface address to avoid unavailable API calls during compilation

## Testing
- pio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ec096b048326aa8446d2e11a1ae2