### PR TITLE
Fix missing declarations for LED helper lookups

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,6 +121,8 @@ void handleWifiScan();
 String htmlEscape(const String& text);
 String jsonEscape(const String& text);
 String wifiAuthModeToText(wifi_auth_mode_t mode);
+const char* getChipName(uint8_t value);
+const char* getColorOrderName(uint8_t value);
 
 AppConfig g_config = makeDefaultConfig();
 


### PR DESCRIPTION
## Summary
- add forward declarations for the LED chip and color-order helper lookups to match their usage in the configuration page renderer

## Testing
- `pio run -e wt32-eth01` *(fails: PlatformIO CLI not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e303c417a88326b0db6b8e60d83878